### PR TITLE
fixed include

### DIFF
--- a/LaMulanaTAS/util.h
+++ b/LaMulanaTAS/util.h
@@ -3,7 +3,7 @@
 #include <vector>
 #include <sal.h>
 #include <memory>
-#include <exception>
+#include <stdexcept>
 #include <d3d9.h>
 #include <atlbase.h>
 


### PR DESCRIPTION
<stdexcept> contains exception types, <exception> does not.